### PR TITLE
Copy functions instead of using `getFromNamespace()`

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1,5 +1,14 @@
-len0_null <- getFromNamespace('len0_null', 'ggplot2')
-modify_list <- getFromNamespace("modify_list", "ggplot2")
+len0_null <- function(x) {
+  if (length(x) == 0) {
+    NULL
+  } else {
+    x
+  }
+}
+modify_list <- function(old, new) {
+  for (i in names(new)) old[[i]] <- new[[i]]
+  old
+}
 .pt <- ggplot2::.pt
 
 


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The problem is using `getFromNamespace()` directly.
As described in https://www.tidyverse.org/blog/2022/09/playing-on-the-same-team-as-your-dependecy/, there are two problems with this:

* It is using something that is not meant for public consumption.
* It is also grabbing the function at *build time*, which gives problems when versions mismatch or the source removes the function.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun